### PR TITLE
Apply rel="noreferrer" to all links

### DIFF
--- a/inc/privacy/namespace.php
+++ b/inc/privacy/namespace.php
@@ -42,6 +42,9 @@ function filter_content( string $content ) : string {
 	foreach ( $post_array['links'] as $link ) {
 		$old_link = $link->getAttribute( 'href' );
 
+		// Set rel="noreferrer" on all links.
+		$link->setAttribute( 'rel', 'noreferrer' );
+
 		// Ignore if the link host is on the network or relative
 		$parsed = parse_url( $old_link );
 		if ( empty( $parsed['host'] ) || strpos( $parsed['host'], $network->domain ) !== false ) {


### PR DESCRIPTION
See https://github.com/humanmade/hmn.md/issues/1663

This applies noreferrer naively to _all_ links, not just external ones, but that felt like it would do no harm and reduce potential issues. It does _not_ address headers and footers, yet.

After making this change in my local, the markdown

```
Local link: [Back to home](/).

Network link: [Updates](https://updates.hmn.md)

Outside: [MDN](https://developer.mozilla.org)
```

converts to

```
<div class="PostContent">
<p>Local link: <a rel="noreferrer" href="/">Back to home</a>.</p>
<p>Network link: <a href="https://href.li/?https://updates.hmn.md" rel="noreferrer">Updates</a></p>
<p>Outside: <a href="https://href.li/?https://developer.mozilla.org" rel="noreferrer">MDN</a></p>
</div>
```