### PR TITLE
Apply short username correction across network

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -92,6 +92,11 @@ function get_active_sites( $check_access = true ) {
  * communication forum.
  */
 function override_settings() {
+	// Allow short usernames.
+	if ( get_site_option( 'h2_allow_short_usernames', false ) ) {
+		add_filter( 'wpmu_validate_user_signup', __NAMESPACE__ . '\\allow_short_usernames' );
+	}
+
 	// Only apply on H2 sites.
 	$theme = get_stylesheet();
 	if ( $theme !== 'h2' ) {
@@ -107,11 +112,6 @@ function override_settings() {
 		add_filter( 'pre_option_comment_max_links', function () {
 			return 100;
 		} );
-	}
-
-	// Allow short usernames.
-	if ( get_site_option( 'h2_allow_short_usernames', false ) ) {
-		add_filter( 'wpmu_validate_user_signup', __NAMESPACE__ . '\\allow_short_usernames' );
 	}
 
 	// Allow all users to view all other users.


### PR DESCRIPTION
Adding users to a multisite happens on the main site. If the main site isn't running H2, this hook will never be added, so the option never has any effect. This is what happens when you have too many safeguards :D